### PR TITLE
[TASK] replace $TYPO3_CONF_VARS in realurl examples

### DIFF
--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -130,7 +130,7 @@ RealURL for beautiful sitemap.xml url
 
 .. code:: php
 
-    $TYPO3_CONF_VARS['EXTCONF']['realurl']['_DEFAULT'] = [
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT'] = [
         'fileName' => [
             'defaultToHTMLsuffixOnPrev' => 0,
             'acceptHTMLsuffix' => 1,
@@ -161,7 +161,7 @@ RealURL for beautiful sitemap\_news.xml url
 
 .. code:: php
 
-    $TYPO3_CONF_VARS['EXTCONF']['realurl']['_DEFAULT'] = [
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT'] = [
         'fileName' => [
             'defaultToHTMLsuffixOnPrev' => 0,
             'acceptHTMLsuffix' => 1,

--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ RealURL for beautiful sitemap.xml url
 
 .. code:: php
 
-    $TYPO3_CONF_VARS['EXTCONF']['realurl']['_DEFAULT'] = [
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT'] = [
         'fileName' => [
             'defaultToHTMLsuffixOnPrev' => 0,
             'acceptHTMLsuffix' => 1,
@@ -147,7 +147,7 @@ RealURL for beautiful sitemap\_news.xml url
 
 .. code:: php
 
-    $TYPO3_CONF_VARS['EXTCONF']['realurl']['_DEFAULT'] = [
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT'] = [
         'fileName' => [
             'defaultToHTMLsuffixOnPrev' => 0,
             'acceptHTMLsuffix' => 1,


### PR DESCRIPTION
Problem with $TYPO3_CONF_VARS is, that it is not unique on its own. While $GLOBALS['TYPO3_CONF_VARS'] points to the global variant of TYPO3_CONF_VARS the $TYPO3_CONF_VARS variant can contain something different in side of classes. So in general the $GLOBALS should be used.