### PR TITLE
[TASK] Prevent exception if a page could not be solved

### DIFF
--- a/Classes/Domain/Repository/SitemapRepository.php
+++ b/Classes/Domain/Repository/SitemapRepository.php
@@ -223,19 +223,17 @@ class SitemapRepository
      * Get sub pages
      *
      * @param int $startPageId
-     *
      * @return array
      */
     private function getSubPages($startPageId)
     {
-        return $this->pageRepository->getMenu(
-            $startPageId,
-            '*',
-            'sorting',
-            $this->pageRepository->enableFields(
-                'pages'
-            ) . ' AND ' . UrlEntry::EXCLUDE_FROM_SITEMAP . '!=1' . $this->pageAdditionalWhere
-        );
+        $where = $this->pageRepository->enableFields('pages')
+            . ' AND ' . UrlEntry::EXCLUDE_FROM_SITEMAP . '!=1' . $this->pageAdditionalWhere;
+        try {
+            return $this->pageRepository->getMenu($startPageId, '*', 'sorting', $where);
+        } catch (\Exception $exception) {
+            return [];
+        }
     }
 
     /**


### PR DESCRIPTION
This helps if there is a page that could (for whatever reason) not be fetched because of a strange doktype etc...
The problem is, that an exception prevents the xml from being rendered what's really a bad thing for google.