### PR TITLE
fix content type header

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -90,7 +90,7 @@ lib.tx_sitemapgenerator {
         xhtml_cleaning = none
         admPanel = 0
         metaCharset = utf-8
-        additionalHeaders.10.header = header = Content-Type: text/xml; charset=utf-8
+        additionalHeaders.10.header = Content-Type: text/xml; charset=utf-8
         disablePrefixComment = 1
     }
 
@@ -107,7 +107,7 @@ lib.tx_sitemapgenerator {
         xhtml_cleaning = none
         admPanel = 0
         metaCharset = utf-8
-        additionalHeaders.10.header = header = Content-Type: text/xml; charset=utf-8
+        additionalHeaders.10.header = Content-Type: text/xml; charset=utf-8
         disablePrefixComment = 1
     }
 

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -90,7 +90,7 @@ lib.tx_sitemapgenerator {
         xhtml_cleaning = none
         admPanel = 0
         metaCharset = utf-8
-        additionalHeaders = Content-Type:text/xml;charset=utf-8
+        additionalHeaders.10.header = header = Content-Type: text/xml; charset=utf-8
         disablePrefixComment = 1
     }
 
@@ -107,7 +107,7 @@ lib.tx_sitemapgenerator {
         xhtml_cleaning = none
         admPanel = 0
         metaCharset = utf-8
-        additionalHeaders = Content-Type:text/xml;charset=utf-8
+        additionalHeaders.10.header = header = Content-Type: text/xml; charset=utf-8
         disablePrefixComment = 1
     }
 
@@ -117,11 +117,5 @@ lib.tx_sitemapgenerator {
         10 < lib.tx_sitemapgenerator
         10.action = googleNewsList
         10.switchableControllerActions.Sitemap.1 = googleNewsList
-    }
-[global]
-
-[globalVar = TSFE:type = 1451160842] && [compatVersion = 7.6.0] || [globalVar = TSFE:type = 1449874941] && [compatVersion = 7.6.0]
-    config {
-        additionalHeaders.10.header = Content-Type:text/xml;charset=utf-8
     }
 [global]

--- a/Tests/Functional/Fixtures/Frontend/EmptyGoogleNewsSitemap.ts
+++ b/Tests/Functional/Fixtures/Frontend/EmptyGoogleNewsSitemap.ts
@@ -2,7 +2,7 @@ config {
 	disableAllHeaderCode = 1
 	admPanel = 0
 	metaCharset = utf-8
-	additionalHeaders = Content-Type:text/xml;charset=utf-8
+	additionalHeaders.10.header = Content-Type: text/xml; charset=utf-8
 	disablePrefixComment = 1
 }
 

--- a/Tests/Functional/Fixtures/Frontend/EmptyNewsRenderer.ts
+++ b/Tests/Functional/Fixtures/Frontend/EmptyNewsRenderer.ts
@@ -2,7 +2,7 @@ config {
 	disableAllHeaderCode = 1
 	admPanel = 0
 	metaCharset = utf-8
-	additionalHeaders = Content-Type:text/xml;charset=utf-8
+	additionalHeaders.10.header = Content-Type: text/xml; charset=utf-8
 	disablePrefixComment = 1
 }
 

--- a/Tests/Functional/Fixtures/Frontend/EmptyPagesRenderer.ts
+++ b/Tests/Functional/Fixtures/Frontend/EmptyPagesRenderer.ts
@@ -2,7 +2,7 @@ config {
 	disableAllHeaderCode = 1
 	admPanel = 0
 	metaCharset = utf-8
-	additionalHeaders = Content-Type:text/xml;charset=utf-8
+	additionalHeaders.10.header = Content-Type: text/xml; charset=utf-8
 	disablePrefixComment = 1
 }
 

--- a/Tests/Functional/Fixtures/Frontend/GoogleNewsSitemap.ts
+++ b/Tests/Functional/Fixtures/Frontend/GoogleNewsSitemap.ts
@@ -2,7 +2,7 @@ config {
 	disableAllHeaderCode = 1
 	admPanel = 0
 	metaCharset = utf-8
-	additionalHeaders = Content-Type:text/xml;charset=utf-8
+	additionalHeaders.10.header = Content-Type: text/xml; charset=utf-8
 	disablePrefixComment = 1
 }
 

--- a/Tests/Functional/Fixtures/Frontend/PagesRenderer.ts
+++ b/Tests/Functional/Fixtures/Frontend/PagesRenderer.ts
@@ -2,7 +2,7 @@ config {
 	disableAllHeaderCode = 1
 	admPanel = 0
 	metaCharset = utf-8
-	additionalHeaders = Content-Type:text/xml;charset=utf-8
+	additionalHeaders.10.header = Content-Type: text/xml; charset=utf-8
 	disablePrefixComment = 1
 }
 

--- a/Tests/Functional/Fixtures/Frontend/PluginRenderer.ts
+++ b/Tests/Functional/Fixtures/Frontend/PluginRenderer.ts
@@ -2,7 +2,7 @@ config {
 	disableAllHeaderCode = 1
 	admPanel = 0
 	metaCharset = utf-8
-	additionalHeaders = Content-Type:text/xml;charset=utf-8
+	additionalHeaders.10.header = Content-Type: text/xml; charset=utf-8
 	disablePrefixComment = 1
 }
 

--- a/Tests/Functional/Fixtures/Frontend/ValidateRenderer.ts
+++ b/Tests/Functional/Fixtures/Frontend/ValidateRenderer.ts
@@ -2,7 +2,7 @@ config {
 	disableAllHeaderCode = 1
 	admPanel = 0
 	metaCharset = utf-8
-	additionalHeaders = Content-Type:text/xml;charset=utf-8
+	additionalHeaders.10.header = Content-Type: text/xml; charset=utf-8
 	disablePrefixComment = 1
 }
 


### PR DESCRIPTION
`config.additinalHeaders` requires an array with numeric indices in TYPO3 8.7 as well
as in TYPO3 7.6.
The TYPO3 7.6 compatibility condition was removed and the setting for additionalHeaders
fixed in the static template and all tests.
