### PR TITLE
[BUGFIX] don't include pages which are hidden in default translation

### DIFF
--- a/Classes/Domain/Repository/SitemapRepository.php
+++ b/Classes/Domain/Repository/SitemapRepository.php
@@ -141,6 +141,7 @@ class SitemapRepository
             return;
         }
         $pages = $this->hidePagesIfNotTranslated($this->getPages());
+        $pages = $this->hidePagesIfHiddenInDefaultTranslation($pages);
 
         $this->getEntriesFromPages($pages);
     }
@@ -177,6 +178,28 @@ class SitemapRepository
         $ifNotTranslated = $this->pluginConfig['1']['urlEntries.']['pages.']['hidePagesIfNotTranslated'];
 
         return (int)$language !== 0 && (int)$ifNotTranslated === 1;
+    }
+
+    /**
+     * Remove page if hidden in default translation
+     *
+     * @param array $pages
+     *
+     * @return array
+     */
+    private function hidePagesIfHiddenInDefaultTranslation($pages)
+    {
+        $language = GeneralUtility::_GET('L');
+
+        if ($language == 0) {
+            foreach ($pages as $key => $page) {
+                if ($page['l18n_cfg'] === 1) {
+                    unset($pages[$key]);
+                }
+            }
+        }
+
+        return $pages;
     }
 
     /**

--- a/Classes/Domain/Repository/SitemapRepository.php
+++ b/Classes/Domain/Repository/SitemapRepository.php
@@ -191,11 +191,13 @@ class SitemapRepository
     {
         $language = GeneralUtility::_GET('L');
 
-        if ($language == 0) {
-            foreach ($pages as $key => $page) {
-                if ($page['l18n_cfg'] === 1) {
-                    unset($pages[$key]);
-                }
+        if ($language != 0) {
+            return $pages;
+        }
+
+        foreach ($pages as $key => $page) {
+            if ($page['l18n_cfg'] === 1) {
+                unset($pages[$key]);
             }
         }
 


### PR DESCRIPTION
If a page has l18n_cfg set to 1, don't include it into the sitemap.

Fixes: #49