### PR TITLE
[BUGFIX] set lastmod to field SYS_LASTCHANGED instead of tstamp

### DIFF
--- a/Classes/Domain/Repository/SitemapRepository.php
+++ b/Classes/Domain/Repository/SitemapRepository.php
@@ -274,7 +274,7 @@ class SitemapRepository
                 $urlEntry = GeneralUtility::makeInstance(UrlEntry::class);
                 $uri = PageUrlService::generatePageUrl($page['uid']);
                 $urlEntry->setLoc($uri);
-                $urlEntry->setLastmod(date('Y-m-d', $page['tstamp']));
+                $urlEntry->setLastmod(date('Y-m-d', $page['SYS_LASTCHANGED']));
                 if (isset($page['sitemap_priority'])) {
                     $urlEntry->setPriority(number_format($page['sitemap_priority'] / 10, 1, '.', ''));
                 }


### PR DESCRIPTION
The database field `tstamp` only shows the date of the last modification of the page properties. For the pages sitemap it's more relevant when the last change was on the content.