### PR TITLE
Add typoscript example into readme if speaking urls with realurl not generated correctly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,3 +160,18 @@ RealURL for beautiful sitemap\_news.xml url
             ]
         ]
     ];
+
+
+Speaking Urls for the sitemap with RealURL
+------------------------------------------
+
+If the speaking urls should not work within the sitemap, the following must be included in the typoscript
+
+Enable for pagetype 1449874941
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    [globalVar = TSFE:type = 1449874941]
+        config.tx_realurl_enable = 1
+    [global]


### PR DESCRIPTION
No speaking urls were created in my sitemap, I had to add the following snippet to the typoscript:

```
    [globalVar = TSFE:type = 1449874941]
        config.tx_realurl_enable = 1
    [global]
```